### PR TITLE
Oni story 0002 mal auth

### DIFF
--- a/oni-search/index.js
+++ b/oni-search/index.js
@@ -1,5 +1,8 @@
-module.exports = async function (context, req) {
+const oniAuth = require("../services/oni-auth");
+require('dotenv').config();
 
+module.exports = async (context, req) => {
+    const _oniAuth = new oniAuth();
     try {
         context.log('oni-search processed search.');
 
@@ -13,17 +16,19 @@ module.exports = async function (context, req) {
                 status: 400
             };
             return;
-        }
+        };
 
         // Add or change code here
-        const message = `search by: ${value}`;
+        _oniAuth.requestMALAuthorization();       
 
         // Construct response
         const responseJSON = {
             "value": value,
             "message": message,
-            "success": true
-        }
+            "success": true,
+            "verifier": _oniAuth.code_verifier,
+            "challenge": _oniAuth.code_challenge
+        };
 
         context.res = {
             // status: 200, /* Defaults to 200 */
@@ -36,5 +41,5 @@ module.exports = async function (context, req) {
             status: 500,
             err: err.message
         };
-    }
-}
+    };
+};

--- a/oni-search/index.js
+++ b/oni-search/index.js
@@ -2,7 +2,26 @@ const oniAuth = require("../services/oni-auth");
 require('dotenv').config();
 
 module.exports = async (context, req) => {
-    const _oniAuth = new oniAuth();
+    const dispatchResponse = (data) => {
+        // Construct response
+        const responseJSON = {
+            "value": value,
+            "success": true,
+        };
+
+        context.res = {
+            // status: 200, /* Defaults to 200 */
+            body: responseJSON,
+            contentType: 'application/json'
+        };
+    }
+
+    const conductSearch = async (searchTerm) => {
+        fetch(`${process.env.KITSU_API_ROOT/SEARCH_ENDPOINT}=${searchTerm}`, {
+            "mode":
+        });
+    }
+    
     try {
         context.log('oni-search processed search.');
 
@@ -19,22 +38,8 @@ module.exports = async (context, req) => {
         };
 
         // Add or change code here
-        _oniAuth.requestMALAuthorization();       
+        await 
 
-        // Construct response
-        const responseJSON = {
-            "value": value,
-            "message": message,
-            "success": true,
-            "verifier": _oniAuth.code_verifier,
-            "challenge": _oniAuth.code_challenge
-        };
-
-        context.res = {
-            // status: 200, /* Defaults to 200 */
-            body: responseJSON,
-            contentType: 'application/json'
-        };
     } catch(err) {
         //testable without async
         context.res = {

--- a/oni-search/index.js
+++ b/oni-search/index.js
@@ -1,27 +1,23 @@
-const oniAuth = require("../services/oni-auth");
-require('dotenv').config();
+const axios = require("axios");
+
+const conductSearch = async (term) => {
+    let response;
+    try {
+        await axios.get("https://kitsu.io/api/edge/anime?", {
+            "params": {
+                "filter[text]": encodeURIComponent(term)
+            }
+        }).then((res) => {
+            response = res.data;
+        });
+    } catch (err) {
+        throw new Error(`search failed: ${err}`);
+    }
+
+    return response;
+}
 
 module.exports = async (context, req) => {
-    const dispatchResponse = (data) => {
-        // Construct response
-        const responseJSON = {
-            "value": value,
-            "success": true,
-        };
-
-        context.res = {
-            // status: 200, /* Defaults to 200 */
-            body: responseJSON,
-            contentType: 'application/json'
-        };
-    }
-
-    const conductSearch = async (searchTerm) => {
-        fetch(`${process.env.KITSU_API_ROOT/SEARCH_ENDPOINT}=${searchTerm}`, {
-            "mode":
-        });
-    }
-    
     try {
         context.log('oni-search processed search.');
 
@@ -32,13 +28,25 @@ module.exports = async (context, req) => {
         if (!value) {
 
             context.res = {
-                status: 400
+                status: 400,
+                message: "include valid search term"
             };
             return;
         };
 
         // Add or change code here
-        await 
+        const result = await conductSearch(value);
+
+        const responseJSON = {
+            "value": result,
+            "success": true,
+        };
+
+        context.res = {
+            // status: 200, /* Defaults to 200 */
+            body: responseJSON,
+            contentType: 'application/json'
+        };
 
     } catch(err) {
         //testable without async

--- a/package-lock.json
+++ b/package-lock.json
@@ -870,11 +870,24 @@
         "sprintf-js": "~1.0.2"
       }
     },
+    "array-uniq": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.2.tgz",
+      "integrity": "sha1-X8w3OSB3VyPP1k1lxkvvU7+eum0="
+    },
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
       "dev": true
+    },
+    "axios": {
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.22.0.tgz",
+      "integrity": "sha512-Z0U3uhqQeg1oNcihswf4ZD57O3NrR1+ZXhxaROaWpDmsDTx7T2HNBV2ulBtie2hwJptu8UvgnJoK+BIqdzh/1w==",
+      "requires": {
+        "follow-redirects": "^1.14.4"
+      }
     },
     "babel-jest": {
       "version": "27.2.4",
@@ -952,6 +965,11 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
+    },
+    "base64url": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/base64url/-/base64url-3.0.1.tgz",
+      "integrity": "sha512-ir1UPr3dkwexU7FdV8qBBbNDRUhMmIekYMFZfi+C/sLNnRESKPl23nB9b2pltqfOQNnGzsDdId90AEtG5tCx4A=="
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -1377,6 +1395,11 @@
         "locate-path": "^5.0.0",
         "path-exists": "^4.0.0"
       }
+    },
+    "follow-redirects": {
+      "version": "1.14.4",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.4.tgz",
+      "integrity": "sha512-zwGkiSXC1MUJG/qmeIFH2HBJx9u0V46QGUe3YR1fXG8bXQxq7fLj0RjLZQ5nubr9qNJUZrH+xUcwXEoXNpfS+g=="
     },
     "form-data": {
       "version": "3.0.1",
@@ -2559,6 +2582,20 @@
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
       "dev": true
+    },
+    "randombytes": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.3.tgz",
+      "integrity": "sha1-Z0yZdgkBw8QRJ3GjHlIdw0nMCew="
+    },
+    "randomstring": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/randomstring/-/randomstring-1.2.1.tgz",
+      "integrity": "sha512-eMnfell9XuU3jfCx3f4xCaFAt0YMFPZhx9R3PSStmLarDKg5j5vivqKhf/8pvG+VX/YkxsckHK/VPUrKa5V07A==",
+      "requires": {
+        "array-uniq": "1.0.2",
+        "randombytes": "2.0.3"
+      }
     },
     "react-is": {
       "version": "17.0.2",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,10 @@
     "test": "jest"
   },
   "dependencies": {
-    "dotenv": "^10.0.0"
+    "axios": "^0.22.0",
+    "base64url": "^3.0.1",
+    "dotenv": "^10.0.0",
+    "randomstring": "^1.2.1"
   },
   "devDependencies": {
     "jest": "^27.2.4"

--- a/services/oni-auth.js
+++ b/services/oni-auth.js
@@ -1,0 +1,51 @@
+'use strict'
+const randomString = require("randomstring");
+const { createHash } = require("crypto");
+const { fromBase64 } = require("base64url");
+const { env } = require("process");
+const axios = require("axios");
+require('dotenv').config();
+ 
+module.exports = class oniAuth {   
+    auth_endpoint = env.MAL_OAUTH_ENDPOINT;
+    response_type = "code";
+    client_id = env.MAL_APP_ID;
+    request_state = "";
+
+    constructor() {
+        this.code_verifier = randomString.generate(128);
+    };
+
+    get code_challenge() {
+        return this.generateCodeChallenge();
+    };
+
+    generateCodeChallenge = () => {
+        const generated_digest = createHash("sha256").update(this.code_verifier).digest("base64");
+
+        const challenge = fromBase64(generated_digest);
+
+        return challenge;
+    };
+
+    requestMALAuthorization = async () => {
+        try {
+            await axios({
+                "method": "get",
+                "url": env.MAL_OAUTH_ENDPOINT,
+                "params": { 
+                    "reponse_type": this.response_type,
+                    "client_id": this.client_id,
+                    "code_challenge": this.code_challenge
+                },
+                "data": {
+                    "grant_type":"client_credentials"
+                }
+            }).then((res) => {
+                console.log(`response recieved: ${res}`);
+            });
+        } catch (err) {
+            console.error(`request for authorization failed - Status: ${err}`); 
+        }
+    }
+};

--- a/services/oni-auth.js
+++ b/services/oni-auth.js
@@ -30,16 +30,15 @@ module.exports = class oniAuth {
 
     requestMALAuthorization = async () => {
         try {
-            await axios({
-                "method": "get",
-                "url": env.MAL_OAUTH_ENDPOINT,
+            await fetch(env.MAL_OAUTH_ENDPOINT, {
+                "method": "POST",
                 "params": { 
                     "reponse_type": this.response_type,
                     "client_id": this.client_id,
                     "code_challenge": this.code_challenge
                 },
                 "data": {
-                    "grant_type":"client_credentials"
+                    "grant_type": client_credentials
                 }
             }).then((res) => {
                 console.log(`response recieved: ${res}`);


### PR DESCRIPTION
I chose to strip out the MAL api because it had no grant for server based http requests, only client side authorization bound to a user account. Kitsu is synced with multiple databases, including MAL and Aozora, while also having a far more adaptive API. I can make most requests without any sort of key - though that is still under development and hasn't been implemented. I'll be switch any future development over to the Kitsu API.